### PR TITLE
Fix some descriptions in README

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -89,10 +89,14 @@ docker-compose up -d
     <img src="assets/02_set_prompt.png" alt="プロンプト設定" width="300" />
 </div>
 
+- [プロンプト例](prompts/prompt.ja.md)
+
 3. ナレッジテンプレートを追加する（オプション）
 <div align="center" style="display: flex; gap: 20px;">
     <img src="assets/03_set_knowledge.png" alt="ナレッジ追加" width="300" />
 </div>
+
+- [ナレッジテンプレート例](prompts/knowledge.md)
 
 ## Star History
 

--- a/README.md
+++ b/README.md
@@ -95,10 +95,14 @@ This command will:
     <img src="assets/02_set_prompt.png" alt="Set prompt" width="300" />
 </div>
 
+- [Prompt example](prompts/prompt.ja.md)
+
 3. Add knowledge template (optional)
 <div align="center" style="display: flex; gap: 20px;">
     <img src="assets/03_set_knowledge.png" alt="Add knowledge" width="300" />
 </div>
+
+- [Knowledge template example](prompts/knowledge.md)
 
 ## Star History
 


### PR DESCRIPTION
Added the storage links for Prompt template samples and Knowledge template samples to the following files:

README.md
README.js.md