### PR TITLE
clarifying container name

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,8 @@ services:
     ports:
       - "9999:9999"
     restart: unless-stopped
-    stdin_open: true 
+    stdin_open: true
+    container_name: claude_hands-claudecode-1 
 
   tavily:
     image: r488it/tavily
@@ -17,3 +18,4 @@ services:
     stdin_open: true 
     environment:
       - TAVILY_API_KEY=${TAVILY_API_KEY}
+    container_name: claude_hands-tavily-1

--- a/docker-compose_amd64.yml
+++ b/docker-compose_amd64.yml
@@ -8,6 +8,7 @@ services:
       - "9999:9999"
     restart: unless-stopped
     stdin_open: true 
+    container_name: claude_hands-claudecode-1
 
   tavily:
     image: myoshida2/tavily-amd64
@@ -15,3 +16,4 @@ services:
     stdin_open: true 
     environment:
       - TAVILY_API_KEY=${TAVILY_API_KEY}
+    container_name: claude_hands-tavily-1


### PR DESCRIPTION
podman-compose --file docker-compose_amd64.yml up -d を実行した際、
コンテナ名が claude_hands_claudecode_1 のようにアンダースコア区切りで生成されていました。

一方で、Claudeが参照する claude_desktop_config_podman.json には
コンテナ名が claude_hands-claudecode-1 のようにハイフン区切りで記載されていたため、
ClaudeでMCPサーバーを扱えない状況でした。
おそらくDockerとPodmanでのコンテナ名の命名規則の違いによるものと考えられます。

この問題を解決するために、Docker Composeファイルで container_name を明示的に指定するようにし、
コンテナ名を claude_desktop_config_podman.json に記載されている名称で統一しました。